### PR TITLE
Possible bug fix - SerializationHelpers.ConvertQueryStringToJson

### DIFF
--- a/src/WebApiService/Code/SerializationHelpers.cs
+++ b/src/WebApiService/Code/SerializationHelpers.cs
@@ -25,7 +25,7 @@
                 let json = dictionary.ContainsKey(propertyName)
                     ? HttpUtility.JavaScriptStringEncode(dictionary[propertyName], true)
                     : ConvertDictionaryToJson(FilterByPropertyName(dictionary, propertyName))
-                select propertyName + ": " + json;
+                select HttpUtility.JavaScriptStringEncode(propertyName, true) + ": " + json;
 
             return "{ " + string.Join(", ", data) + " }";
         }


### PR DESCRIPTION
Hey dotnetjunkie,

I noticed the SerializationHelpers.ConvertQueryStringToJson does not return quotes around the property names.  This is giving me problems when using the DataContractJsonSerializer.  This PR seems to solve the problem for me.  Let me know your thoughts.  Thanks!

PS. Great Project!  Thanks for sharing!
